### PR TITLE
macOS Tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,10 @@ on:
   push:
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    strategy: 
+      matrix: 
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2.3.1
     - uses: cachix/install-nix-action@v10

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,8 +1,12 @@
-import (builtins.fetchGit {
+let
+  baseUrl = "https://github.com/nixos/nixpkgs-channels";
+  # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
+  rev = "96069f7d890b90cbf4e8b4b53e15b036210ac146";
+in
+
+import (builtins.fetchTarball {
   # Descriptive name to make the store path easier to identify
   name = "nixos-unstable-2020-08-10";
-  url = "https://github.com/nixos/nixpkgs-channels/";
-  # `git ls-remote https://github.com/nixos/nixpkgs-channels nixos-unstable`
-  ref = "refs/heads/nixos-unstable";
-  rev = "96069f7d890b90cbf4e8b4b53e15b036210ac146";
+  url = "${baseUrl}/archive/${rev}.tar.gz";
+  sha256 = "0ixyfsw7p0gq9w7hzamgnvk8xjnf62niygmpi39zh2a312k94lqr";
 })

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,8 @@
 , compiler ? "ghc865" }:
 let
   fonts = with pkgs; [ libre-baskerville iosevka opensans-ttf ];
+  inherit (pkgs.lib.systems.elaborate { system = builtins.currentSystem; })
+    isLinux;
 
   easy-ps = import ./dsl/easy-ps.nix { inherit pkgs; };
   dsl = import ./dsl { inherit pkgs; };
@@ -37,11 +39,6 @@ in quickstrom.haskellPackages.shellFor {
     quickstrom.haskellPackages.ormolu
     easy-ps.purty
 
-    firefox
-    geckodriver
-    # chromium
-    # chromedriver
-
     quickstrom-purs-ide
     quickstrom-format-sources
 
@@ -51,6 +48,11 @@ in quickstrom.haskellPackages.shellFor {
     # only for lorri
     dsl
     client-side
+  ] ++ lib.optional isLinux [
+    firefox
+    geckodriver
+    # chromium
+    # chromedriver
   ]);
   FONTCONFIG_FILE = pkgs.makeFontsConf { fontDirectories = fonts; };
   QUICKSTROM_LIBRARY_DIR = "${dsl}";


### PR DESCRIPTION
A few small tweaks here that may be helpful for people developing/testing on macOS.

1. c713a96 - `fetchTarball` is usually faster than `fetchGit` for large Git repositories, since `fetchGit` actually uses `git` under the hood
    - with the original derivation, my terminal was unresponsive for a few minutes and I killed `nix-shell`
2. 68a0042 - this was copy/paste from my dotfiles, but perhaps `pkgs.stdenv.isLinux` would be more convenient here...
3. 684320f - ensure this is built on a macOS VM and the associated cachix cache is pushed up via the action
    - this should be as simple as adding macOS to the build matrix; cf. [`this project`](https://github.com/haskell-nix/haskell-with-nixpkgs/blob/master/.github/workflows/Nixpkgs-macOS.yml)