### PR TITLE
Bug fix for Docker example in docs: make Geckodriver container only accept connections from localhost

### DIFF
--- a/docs/source/installation/docker.rst
+++ b/docs/source/installation/docker.rst
@@ -22,7 +22,7 @@ run``:
 .. code-block:: console
    :linenos:
 
-   $ docker run -d -p 4444:4444 instrumentisto/geckodriver
+   $ docker run -d -p 127.0.0.1:4444:4444 instrumentisto/geckodriver
    $ docker run \
      --network=host \
      --mount=type=bind,source=$PWD/specs,target=/specs \


### PR DESCRIPTION
This is a fix for issue #38.
