### PR TITLE
New API for actions in DSL

### DIFF
--- a/cli/app/Main.hs
+++ b/cli/app/Main.hs
@@ -26,7 +26,6 @@ import Data.Text.Prettyprint.Doc.Symbols.Unicode (bullet)
 import Options.Applicative
 import qualified Pipes as Pipes
 import qualified Quickstrom.Browser as Quickstrom
-import qualified Quickstrom.Timeout as Quickstrom
 import qualified Quickstrom.CLI.Logging as Quickstrom
 import Quickstrom.CLI.Reporter (Reporter)
 import qualified Quickstrom.CLI.Reporter as Reporter
@@ -37,6 +36,7 @@ import qualified Quickstrom.LogLevel as Quickstrom
 import Quickstrom.Prelude hiding (option, try)
 import qualified Quickstrom.PureScript.Program as Quickstrom
 import qualified Quickstrom.Run as Quickstrom
+import qualified Quickstrom.Timeout as Quickstrom
 import qualified Quickstrom.Trace as Quickstrom
 import qualified Quickstrom.WebDriver.Class as Quickstrom
 import qualified Quickstrom.WebDriver.WebDriverW3C as WebDriver

--- a/docs/source/topics/specification-language.rst
+++ b/docs/source/topics/specification-language.rst
@@ -191,40 +191,46 @@ Actions
 -------
 
 We must instruct Quickstrom what actions it should try. The ``actions``
-definition in a specification module has the following type:
+definition in a specification module is where you list possible actions.
 
 .. code-block:: haskell
 
-   Array (Tuple Int ActionSequence)
+   actions = [ action1, action2, ... ]
 
-It's an array of pairs, or tuples, where each pair holds a weight and a
-sequence of actions. The weight specifies the intended probability
-of the sequence being picked, relative to the other sequences.
+It's an array of values, where each value describes an action or a fixed
+sequence of actions. Each action also carries a weight, which specifies the
+intended probability of the action being picked, relative to the other
+actions.
 
-To illustrate, in the following array of action sequences, the probability of 
-``a1`` being picked is 40%, while the others are at 20% each. This is assuming 
-the first action in each sequence is *possible* at each point a sequence is being
-picked.
+The default weight is ``1``. To override it, use the ``weighted`` function:
+
+.. code-block:: haskell
+
+   importantAction = click "#important-action" `weighted` 10
+
+To illustrate, in the following array of actions, the probability of ``a1``
+being picked is 40%, while the others are at 20% each. This is assuming the
+action (or the first action in each sequence) is *possible* at each point a
+sequence is being picked.
 
 .. code-block::
 
    actions = [
-       Tuple 2 a1,
-       Tuple 1 a2,
-       Tuple 1 a3,
-       Tuple 1 a4
+       a1 `weighted` 2,
+       a2,
+       a3,
+       a4
      ]
 
 Action Sequences
 ~~~~~~~~~~~~~~~~
 
-An action sequence is either a single action or a fixed sequence of actions:
+An action sequence is either a single action or a fixed sequence of actions.
+Here's a simple sequence:
 
-.. code-block:: haskell
+.. code-block::
 
-   data ActionSequence 
-      = Single Action 
-      | Sequence (Array Action)
+   backAndForth = click "#back" `followedBy` click "#forward"
 
 A sequence of actions is always performed in its entirety when picked, as
 long as the first action in the sequence is considered possible by the test
@@ -233,36 +239,45 @@ runner.
 Actions
 ~~~~~~~
 
-The ``Action`` data type is defined in the Quickstrom library, along with
-some aliases for common actions. For instance, here's the definition of
-``foci``:
+The action functions are defined in the Quickstrom library:
+
+* ``focus``
+* ``keyPress``
+* ``enterText``
+* ``click``
+* ``clear``
+* ``await``
+* ``awaitWithTimeoutSecs``
+* ``navigate``
+* ``refresh``
+
+Along with those functions, there are some aliases for common actions. For
+instance, here's the definition of ``foci``:
 
 .. code-block:: haskell
 
    -- | Generate focus actions on common focusable elements.
    foci :: Actions
    foci = 
-      [ Tuple 1 (Single (Focus "input"))
-      , Tuple 1 (Single (Focus "textarea"))
+      [ focus "input"
+      , focus "textarea"
       ]
 
-More action constructors and aliases should be introduced as Quickstrom
-evolves.
+More actions and aliases should be introduced as Quickstrom evolves.
 
 Example
 ~~~~~~~
 
 As an example of composing actions and sequences of actions, here's a
-collection of actions that try to log in and to click a buy button:
+collection of actions that try to log in or to click a buy button:
 
 .. code-block:: haskell
 
    foci = 
-      [ Tuple 1 (Sequence [ Focus "input[type=password]"
-                          , EnterText "$ecr3tz"
-                          , Click "input[type=submit][name=log-in]"
-                          ])
-      , Tuple 1 (Single (Click "input[type=submit][name=buy]"))
+      [ focus "input[type=password]"
+          `followedBy` enterText "$ecr3tz"
+          `followedBy` click "input[type=submit][name=log-in]"
+      , click "input[type=submit][name=buy]"
       ]
 
 .. note::

--- a/docs/source/topics/specification-language.rst
+++ b/docs/source/topics/specification-language.rst
@@ -214,7 +214,7 @@ being picked is 40%, while the others are at 20% each. This is assuming the
 action (or the first action in each sequence) is *possible* at each point a
 sequence is being picked.
 
-.. code-block::
+.. code-block:: haskell
 
    actions = [
        a1 `weighted` 2,
@@ -229,7 +229,7 @@ Action Sequences
 An action sequence is either a single action or a fixed sequence of actions.
 Here's a simple sequence:
 
-.. code-block::
+.. code-block:: haskell
 
    backAndForth = click "#back" `followedBy` click "#forward"
 

--- a/docs/source/topics/specification-language.rst
+++ b/docs/source/topics/specification-language.rst
@@ -207,7 +207,7 @@ The default weight is ``1``. To override it, use the ``weighted`` function:
 
 .. code-block:: haskell
 
-   importantAction = click "#important-action" `weighted` 10
+   click "#important-action" `weighted` 10
 
 To illustrate, in the following array of actions, the probability of ``a1``
 being picked is 40%, while the others are at 20% each. This is assuming the
@@ -274,7 +274,7 @@ collection of actions that try to log in or to click a buy button:
 
 .. code-block:: haskell
 
-   foci = 
+   actions = 
       [ focus "input[type=password]"
           `followedBy` enterText "$ecr3tz"
           `followedBy` click "input[type=submit][name=log-in]"

--- a/docs/source/topics/specification-language.rst
+++ b/docs/source/topics/specification-language.rst
@@ -195,6 +195,7 @@ definition in a specification module is where you list possible actions.
 
 .. code-block:: haskell
 
+   actions :: Actions
    actions = [ action1, action2, ... ]
 
 It's an array of values, where each value describes an action or a fixed
@@ -239,7 +240,7 @@ runner.
 Actions
 ~~~~~~~
 
-The action functions are defined in the Quickstrom library:
+The available actions are provided in the Quickstrom library:
 
 * ``focus``
 * ``keyPress``

--- a/dsl/spago.dhall
+++ b/dsl/spago.dhall
@@ -3,7 +3,7 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "quickstrom"
-, dependencies = [ "numbers", "strings", "arrays", "typelevel-prelude", "lcg", "transformers", "generics-rep", "nonempty" ]
+, dependencies = [ "numbers", "strings", "arrays", "typelevel-prelude", "lcg", "transformers", "generics-rep" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/dsl/spago.dhall
+++ b/dsl/spago.dhall
@@ -3,7 +3,7 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "quickstrom"
-, dependencies = [ "numbers", "strings", "arrays", "typelevel-prelude", "lcg", "transformers", "generics-rep" ]
+, dependencies = [ "numbers", "strings", "arrays", "typelevel-prelude", "lcg", "transformers", "generics-rep", "nonempty" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/dsl/src/Quickstrom.js
+++ b/dsl/src/Quickstrom.js
@@ -6,7 +6,6 @@
 exports._next = null;
 exports._always = null;
 exports._until = null;
-exports._log = null;
 exports._queryAll = null;
 exports._property = null;
 exports._attribute = null;

--- a/dsl/src/Quickstrom.purs
+++ b/dsl/src/Quickstrom.purs
@@ -20,6 +20,7 @@ module Quickstrom
   , unchanged
   , module Quickstrom.Selector
   , module Spec
+  , module NonEmpty
   , module Data.HeytingAlgebra
   , module Prelude
   ) where
@@ -27,11 +28,12 @@ module Quickstrom
 import Prelude
 import Data.Array (head)
 import Data.Maybe (Maybe)
+import Data.NonEmpty (NonEmpty(..), (:|)) as NonEmpty
 import Data.HeytingAlgebra (implies)
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Prim.RowList (class RowToList, Cons, Nil, kind RowList)
 import Quickstrom.Selector (Selector)
-import Quickstrom.Spec (Actions, ProbabilisticAction, Action(..), class ToActionSequence, toActionSequence, weighted, Path, SpecialKey(..), asciiKeyPresses, clicks, foci, focus, keyPress, specialKeyPress) as Spec
+import Quickstrom.Spec (class ToAction, Actions, Path, ProbabilisticAction, SpecialKey(..), asciiKeyPresses, await, awaitWithTimeoutSecs, clear, click, clicks, enterText, foci, focus, keyPress, navigate, refresh, specialKeyPress, toAction, weighted) as Spec
 import Type.Prelude (class ListToRow, class TypeEquals)
 
 -- ## Temporal operators

--- a/dsl/src/Quickstrom.purs
+++ b/dsl/src/Quickstrom.purs
@@ -31,7 +31,7 @@ import Data.HeytingAlgebra (implies)
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Prim.RowList (class RowToList, Cons, Nil, kind RowList)
 import Quickstrom.Selector (Selector)
-import Quickstrom.Spec (Actions, ProbabilisticAction, Action(..), ActionSequence(..), Path, SpecialKey(..), asciiKeyPresses, clicks, foci, focus, keyPress, specialKeyPress) as Spec
+import Quickstrom.Spec (Actions, ProbabilisticAction, Action(..), class ToActionSequence, toActionSequence, weighted, Path, SpecialKey(..), asciiKeyPresses, clicks, foci, focus, keyPress, specialKeyPress) as Spec
 import Type.Prelude (class ListToRow, class TypeEquals)
 
 -- ## Temporal operators

--- a/dsl/src/Quickstrom.purs
+++ b/dsl/src/Quickstrom.purs
@@ -33,7 +33,7 @@ import Data.HeytingAlgebra (implies)
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Prim.RowList (class RowToList, Cons, Nil, kind RowList)
 import Quickstrom.Selector (Selector)
-import Quickstrom.Spec (class ToAction, Actions, Path, ProbabilisticAction, SpecialKey(..), asciiKeyPresses, await, awaitWithTimeoutSecs, clear, click, clicks, enterText, foci, focus, keyPress, navigate, refresh, specialKeyPress, toAction, weighted) as Spec
+import Quickstrom.Spec (class ToAction, Actions, Path, ProbabilisticAction, SpecialKey(..), asciiKeyPresses, await, awaitWithTimeoutSecs, clear, click, clicks, enterText, foci, focus, keyPress, navigate, refresh, specialKeyPress, toAction, followedBy, weighted) as Spec
 import Type.Prelude (class ListToRow, class TypeEquals)
 
 -- ## Temporal operators

--- a/dsl/src/Quickstrom/Spec.purs
+++ b/dsl/src/Quickstrom/Spec.purs
@@ -5,6 +5,7 @@ module Quickstrom.Spec
   , ProbabilisticAction
   , class ToAction
   , toAction
+  , followedBy
   , weighted
   -- Actions
   , focus
@@ -27,7 +28,6 @@ module Quickstrom.Spec
 import Prelude
 
 import Data.Array (range)
-import Data.Array.NonEmpty (NonEmptyArray, singleton, snoc)
 import Data.Char (fromCharCode)
 import Data.Enum (class Enum)
 import Data.Generic.Rep (class Generic)
@@ -59,7 +59,7 @@ type Weighted a = {weight :: Int, weighted :: a}
 
 -- | An action (or fixed sequence of actions) carrying a 
 -- | weight, representing its relative probability of being chosen.
-newtype ProbabilisticAction = ProbabilisticAction (Weighted (NonEmptyArray Action))
+newtype ProbabilisticAction = ProbabilisticAction (Weighted (Array Action))
 
 -- | An array of tuples, containing probabilistic weights and 
 -- | action sequences.
@@ -74,10 +74,10 @@ instance toActionAction :: ToAction Action where
   toAction = identity
 
 instance toActionProbabilisticAction :: ToAction ProbabilisticAction where
-  toAction a = ProbabilisticAction { weighted: singleton a, weight: 1 }
+  toAction a = ProbabilisticAction { weighted: pure a, weight: 1 }
 
 followedBy :: ProbabilisticAction -> Action -> ProbabilisticAction
-followedBy (ProbabilisticAction p) a = ProbabilisticAction (p { weighted = p.weighted `snoc` a })
+followedBy (ProbabilisticAction p) a = ProbabilisticAction (p { weighted = p.weighted <> pure a })
 
 weighted :: ProbabilisticAction -> Int -> ProbabilisticAction
 weighted (ProbabilisticAction a) w = ProbabilisticAction a { weight = w }

--- a/dsl/src/Quickstrom/Spec.purs
+++ b/dsl/src/Quickstrom/Spec.purs
@@ -129,12 +129,12 @@ foci =
   ]
 
 -- | Generate key press actions with printable ASCII characters.
-asciiKeyPresses :: Array Action
-asciiKeyPresses = KeyPress <<< unsafePartial fromJust <<< fromCharCode <$> range 32 126
+asciiKeyPresses :: forall a. ToAction a => Array a
+asciiKeyPresses = toAction <<< KeyPress <<< unsafePartial fromJust <<< fromCharCode <$> range 32 126
 
 -- | Generate a key press action with the given special key.
-specialKeyPress :: SpecialKey -> Action
-specialKeyPress specialKey = KeyPress (specialKeyToChar specialKey)
+specialKeyPress :: forall a. ToAction a => SpecialKey -> a
+specialKeyPress specialKey = toAction (KeyPress (specialKeyToChar specialKey))
 
 data SpecialKey
   = KeyAdd

--- a/html-report/src/App.tsx
+++ b/html-report/src/App.tsx
@@ -97,9 +97,9 @@ type Action =
     | { tag: "Click", contents: [string, number] }
     | { tag: "Navigate", contents: string };
 
-type ActionSequence =
-    { tag: "Single", contents: Action }
-    | { tag: "Sequence", contents: Action[] };
+type NonEmptyArray<T> = [T, ...T[]];
+
+type ActionSequence = NonEmptyArray<Action>;
 
 type TestViewerState = {
     test: Test,
@@ -352,28 +352,14 @@ const ActionSequence: FunctionComponent<{ actionSequence?: ActionSequence }> = (
     }
 
     if (actionSequence) {
-        switch (actionSequence.tag) {
-            case "Single":
-                return (
-                    <div class="action-sequence">
-                        <div class="action-sequence-inner">
-                            <div class="label">Action</div>
-                            {renderDetails(actionSequence.contents)}
-                        </div>
-                    </div>
-
-                );
-            case "Sequence":
-                return (
-                    <div class="action-sequence">
-                        <div class="action-sequence-inner">
-                            <div class="label">Action Sequence</div>
-                            {actionSequence.contents.map(renderDetails)}
-                        </div>
-                    </div>
-
-                );
-        }
+        return (
+            <div class="action-sequence">
+                <div class="action-sequence-inner">
+                    <div class="label">Action Sequence</div>
+                    {actionSequence.map(renderDetails)}
+                </div>
+            </div>
+        );
     } {
         return null;
     }

--- a/integration-tests/failing/CommentForm.spec.purs
+++ b/integration-tests/failing/CommentForm.spec.purs
@@ -11,14 +11,14 @@ readyWhen = "form"
 
 actions :: Actions
 actions =
-  [ Focus "input[type=text]:nth-child(1)" `weighted` 3
+  [ focus "input[type=text]:nth-child(1)" `weighted` 3
   -- This spec is flaky. It only finds the bug on some runs, so the following action
   -- is commented out to increase chances of a failed example:
   --
   --   , Tuple 1 (Single $ Focus "input[type=text]:nth-child(2)")
-  , Click "input[type=submit]" `weighted` 5
-  , KeyPress ' ' `weighted` 5
-  , KeyPress 'a' `weighted` 5
+  , click "input[type=submit]" `weighted` 5
+  , keyPress ' ' `weighted` 5
+  , keyPress 'a' `weighted` 5
   ]
 
 proposition :: Boolean

--- a/integration-tests/failing/CommentForm.spec.purs
+++ b/integration-tests/failing/CommentForm.spec.purs
@@ -11,14 +11,14 @@ readyWhen = "form"
 
 actions :: Actions
 actions =
-  [ Tuple 3 (Single $ Focus "input[type=text]:nth-child(1)")
+  [ Focus "input[type=text]:nth-child(1)" `weighted` 3
   -- This spec is flaky. It only finds the bug on some runs, so the following action
   -- is commented out to increase chances of a failed example:
   --
   --   , Tuple 1 (Single $ Focus "input[type=text]:nth-child(2)")
-  , Tuple 5 (Single $ Click "input[type=submit]")
-  , Tuple 5 (Single $ KeyPress ' ')
-  , Tuple 5 (Single $ KeyPress 'a')
+  , Click "input[type=submit]" `weighted` 5
+  , KeyPress ' ' `weighted` 5
+  , KeyPress 'a' `weighted` 5
   ]
 
 proposition :: Boolean

--- a/integration-tests/other/FileUpload.spec.purs
+++ b/integration-tests/other/FileUpload.spec.purs
@@ -6,7 +6,7 @@ import Data.Tuple (Tuple(..))
 
 readyWhen = "button"
 
-actions = clicks <> [ Tuple 10 (Single $ Click "input[type=file]") ]
+actions = clicks <> [ Click "input[type=file]" `weighted` 10 ]
 
 proposition :: Boolean
 proposition =

--- a/integration-tests/other/FileUpload.spec.purs
+++ b/integration-tests/other/FileUpload.spec.purs
@@ -6,7 +6,7 @@ import Data.Tuple (Tuple(..))
 
 readyWhen = "button"
 
-actions = clicks <> [ Click "input[type=file]" `weighted` 10 ]
+actions = clicks <> [ click "input[type=file]" `weighted` 10 ]
 
 proposition :: Boolean
 proposition =

--- a/integration-tests/other/SwedishTaxCalculation.spec.purs
+++ b/integration-tests/other/SwedishTaxCalculation.spec.purs
@@ -9,6 +9,7 @@ import Data.Int as Int
 import Data.Maybe (Maybe(..), isJust, isNothing)
 import Data.String (trim)
 import Data.Tuple (Tuple(..))
+import Data.Symbol (SProxy(..))
 
 readyWhen :: Selector
 readyWhen = "app-gdpr-modal"
@@ -17,7 +18,7 @@ actions :: Actions
 actions =
   [ (click "app-gdpr-modal #btn-center-confirm") `weighted` 10000000 ]
   <>
-  [ click "#next" `weighted` 1
+  [ click "[role=main] a" `weighted` 1
   , click ".modal-content #btn-abort" `weighted` 5
   , click ".modal-content #btn-close" `weighted` 5
   -- , click ".panel-footer button" `weighted` 2
@@ -47,6 +48,7 @@ proposition =
             || selectMemberInKyrkaOrSamfund
             || continueToInkomst
             || submitWithErrors
+            || toggleAccordion
         )
   where
   initial = isJust gdprModalTitle
@@ -75,6 +77,9 @@ proposition =
       && ( activeWizardTab
             == next activeWizardTab
         )
+  
+  toggleAccordion =
+    accordionExpanded /= next accordionExpanded
 
 gdprModalTitle :: Maybe String
 gdprModalTitle = _.textContent <$> queryOne "app-gdpr-modal .modal-title" { textContent }
@@ -110,3 +115,11 @@ selectedMemberInKyrkaOrSamfund = case _.head.value <$> Array.uncons (Array.filte
   where
   memberInKyrkaOrSamfundRadioButtons :: Array { checked :: Boolean, value :: String }
   memberInKyrkaOrSamfundRadioButtons = queryAll "[name=isMemberInKyrkaOrSamfund]" { value, checked }
+
+ariaExpanded :: Attribute "aria-expanded"
+ariaExpanded = attribute SProxy
+
+accordionExpanded :: Maybe Boolean
+accordionExpanded = do
+  expanded <- _.ariaExpanded =<< queryOne "#accordion-lon-efter-skatt .accordion" { ariaExpanded }
+  pure (expanded == "true")

--- a/integration-tests/other/SwedishTaxCalculation.spec.purs
+++ b/integration-tests/other/SwedishTaxCalculation.spec.purs
@@ -17,10 +17,10 @@ actions :: Actions
 actions =
   [ (click "app-gdpr-modal #btn-center-confirm") `weighted` 10000000 ]
   <>
-  [ click "[role=main] a" `weighted` 1
+  [ click "#next" `weighted` 1
   , click ".modal-content #btn-abort" `weighted` 5
   , click ".modal-content #btn-close" `weighted` 5
-  , click ".panel-footer button" `weighted` 2
+  -- , click ".panel-footer button" `weighted` 2
 
   , click "input[type=radio]" `weighted` 5
   , click "form select option" `weighted` 2
@@ -53,9 +53,7 @@ proposition =
 
   acceptGdpr = isJust gdprModalTitle && next (isNothing gdprModalTitle)
 
-  selectBirthYear = case birthYear of
-    Nothing -> next (isJust birthYear)
-    Just current -> next (isJust birthYear && Just current /= birthYear)
+  selectBirthYear = birthYear /= next birthYear
 
   selectKommun = case kommun of
     Nothing -> next (isJust kommun)

--- a/integration-tests/other/SwedishTaxCalculation.spec.purs
+++ b/integration-tests/other/SwedishTaxCalculation.spec.purs
@@ -11,22 +11,30 @@ import Data.String (trim)
 import Data.Tuple (Tuple(..))
 
 readyWhen :: Selector
-readyWhen = "app-gdpr-modal #btn-center-confirm"
+readyWhen = "app-gdpr-modal"
 
 actions :: Actions
 actions =
-  [ Click "[role=main] a" `weigthed` 1
-  , Click "app-gdpr-modal #btn-center-confirm" `weigthed` 10000000
-  , Click ".modal-content button" `weigthed` 5
-  , Click ".panel-footer button" `weigthed` 2
+  [ (click "app-gdpr-modal #btn-center-confirm") `weighted` 10000000 ]
+  <>
+  [ click "[role=main] a" `weighted` 1
+  , click ".modal-content #btn-abort" `weighted` 5
+  , click ".modal-content #btn-close" `weighted` 5
+  , click ".panel-footer button" `weighted` 2
+
+  , click "input[type=radio]" `weighted` 5
+  , click "form select option" `weighted` 2
+  , click "form .cm-scroll-box input" `weighted` 2
+
   -- targeted form events
-  , Focus "form input" `weigthed` 3
-  , Click "input[type=radio]" `weigthed` 5
-  , Click "form select option" `weigthed` 2
-  , Click "form .cm-scroll-box input" `weigthed` 2
-  , EnterText "1990" `weigthed` 5 -- year
-  , EnterText "1950" `weigthed` 2 -- year
-  , EnterText "19900" `weigthed` 5 -- salary (but also a year, the first 4 chars)
+
+  , focus "#fodelsar" `followedBy` clear "fodelsear" `followedBy` enterText "1950" `weighted` 3
+  , focus "#fodelsar" `followedBy` clear "fodelsear" `followedBy` enterText "1990" `weighted` 3
+  , focus "#fodelsar" `followedBy` clear "fodelsear" `followedBy` enterText "2020" `weighted` 3
+
+  , clear "inkomst" `followedBy` enterText "2020" `weighted` 1
+  , focus "#inkomst" `followedBy` enterText "0" `weighted` 5
+  , focus "#inkomst" `followedBy` enterText "1" `weighted` 5
   ]
 
 proposition :: Boolean

--- a/integration-tests/other/SwedishTaxCalculation.spec.purs
+++ b/integration-tests/other/SwedishTaxCalculation.spec.purs
@@ -15,18 +15,18 @@ readyWhen = "app-gdpr-modal #btn-center-confirm"
 
 actions :: Actions
 actions =
-  [ Tuple 1 (Single $ Click "[role=main] a")
-  , Tuple 10000000 (Single $ Click "app-gdpr-modal #btn-center-confirm")
-  , Tuple 5 (Single $ Click ".modal-content button")
-  , Tuple 2 (Single $ Click ".panel-footer button")
+  [ Click "[role=main] a" `weigthed` 1
+  , Click "app-gdpr-modal #btn-center-confirm" `weigthed` 10000000
+  , Click ".modal-content button" `weigthed` 5
+  , Click ".panel-footer button" `weigthed` 2
   -- targeted form events
-  , Tuple 3 (Focus "form input")
-  , Tuple 5 (Single $ Click "input[type=radio]")
-  , Tuple 2 (Single $ Click "form select option")
-  , Tuple 2 (Single $ Click "form .cm-scroll-box input")
-  , Tuple 5 (Single $ EnterText "1990") -- year
-  , Tuple 2 (Single $ EnterText "1950") -- year
-  , Tuple 5 (Single $ EnterText "19900") -- salary (but also a year, the first 4 chars)
+  , Focus "form input" `weigthed` 3
+  , Click "input[type=radio]" `weigthed` 5
+  , Click "form select option" `weigthed` 2
+  , Click "form .cm-scroll-box input" `weigthed` 2
+  , EnterText "1990" `weigthed` 5 -- year
+  , EnterText "1950" `weigthed` 2 -- year
+  , EnterText "19900" `weigthed` 5 -- salary (but also a year, the first 4 chars)
   ]
 
 proposition :: Boolean

--- a/integration-tests/other/TodoMVC.spec.purs
+++ b/integration-tests/other/TodoMVC.spec.purs
@@ -18,13 +18,13 @@ actions :: Actions
 actions = appFoci <> appClicks <> appKeyPresses
   where
   appClicks =
-    [ Click queries.filters.notSelected `weighted` 5
-    , Click queries.filters.selected `weighted` 1
-    , Click queries.toggleAll `weighted` 1
-    , Click queries.destroy `weighted` 1
+    [ click queries.filters.notSelected `weighted` 5
+    , click queries.filters.selected `weighted` 1
+    , click queries.toggleAll `weighted` 1
+    , click queries.destroy `weighted` 1
     ]
 
-  appFoci = [ Focus queries.newTodo `weighted` 1 ]
+  appFoci = [ focus queries.newTodo `weighted` 1 ]
 
   appKeyPresses =
     [ keyPress 'a' `weighted` 5

--- a/integration-tests/other/TodoMVC.spec.purs
+++ b/integration-tests/other/TodoMVC.spec.purs
@@ -18,17 +18,17 @@ actions :: Actions
 actions = appFoci <> appClicks <> appKeyPresses
   where
   appClicks =
-    [ Tuple 5 (Single $ Click queries.filters.notSelected)
-    , Tuple 1 (Single $ Click queries.filters.selected)
-    , Tuple 1 (Single $ Click queries.toggleAll)
-    , Tuple 1 (Single $ Click queries.destroy)
+    [ Click queries.filters.notSelected `weighted` 5
+    , Click queries.filters.selected `weighted` 1
+    , Click queries.toggleAll `weighted` 1
+    , Click queries.destroy `weighted` 1
     ]
 
-  appFoci = [ Tuple 5 (Single $ Focus queries.newTodo) ]
+  appFoci = [ Focus queries.newTodo `weighted` 1 ]
 
   appKeyPresses =
-    [ Tuple 5 (Single $ keyPress 'a')
-    , Tuple 5 (Single $ specialKeyPress KeyReturn)
+    [ keyPress 'a' `weighted` 5
+    , specialKeyPress KeyReturn `weighted` 5
     ]
 
 proposition :: Boolean

--- a/integration-tests/passing/AudioPlayer.spec.purs
+++ b/integration-tests/passing/AudioPlayer.spec.purs
@@ -39,7 +39,8 @@ proposition =
     tick =
       playing
         && next playing
-        && timeDisplayText < next timeDisplayText
+        && timeDisplayText
+        < next timeDisplayText
   in
     -- This last part is the central part of the specification,
     -- describing the initial state and the possible transitions. It

--- a/integration-tests/passing/FormFillClear.spec.purs
+++ b/integration-tests/passing/FormFillClear.spec.purs
@@ -11,17 +11,17 @@ readyWhen = "body"
 actions :: Actions
 actions =
   clicks
-    <> [ Tuple 1 (Single $ Click "input[type=reset]") ]
-    <> [ Tuple 1 (Single $ Click "input[type=submit]") ]
-    <> [ Tuple 5
-          ( Sequence
-              [ Click "input[type=reset]"
-              , Focus "input[type=email]"
+    <> [ Click "input[type=reset]" `weighted` 1 ]
+    <> [ Click "input[type=submit]" `weighted` 1 ]
+    <> [ ( Click "input[type=reset]"
+            :| [ Focus "input[type=email]"
               , EnterText "jane.doe@example.com"
               , Focus "input[type=number]"
               , EnterText "30"
               ]
-          )
+        )
+          `weigthed`
+            5
       ]
 
 proposition :: Boolean

--- a/integration-tests/passing/FormFillClear.spec.purs
+++ b/integration-tests/passing/FormFillClear.spec.purs
@@ -11,17 +11,14 @@ readyWhen = "body"
 actions :: Actions
 actions =
   clicks
-    <> [ Click "input[type=reset]" `weighted` 1 ]
-    <> [ Click "input[type=submit]" `weighted` 1 ]
-    <> [ ( Click "input[type=reset]"
-            :| [ Focus "input[type=email]"
-              , EnterText "jane.doe@example.com"
-              , Focus "input[type=number]"
-              , EnterText "30"
-              ]
-        )
-          `weigthed`
-            5
+    <> [ click "input[type=reset]" `weighted` 1 ]
+    <> [ click "input[type=submit]" `weighted` 1 ]
+    <> [ click "input[type=reset]"
+           `followedBy` focus "input[type=email]"
+           `followedBy` enterText "jane.doe@example.com"
+           `followedBy` focus "input[type=number]"
+           `followedBy` enterText "30"
+           `weigthed` 5
       ]
 
 proposition :: Boolean

--- a/integration-tests/passing/MultiPage.spec.purs
+++ b/integration-tests/passing/MultiPage.spec.purs
@@ -10,9 +10,9 @@ readyWhen = "body"
 actions :: Actions
 actions =
   clicks
-    <> [ Focus "input[type=text]" `weighted` 5 
-       , KeyPress ' ' `weighted` 5
-       , KeyPress 'a' `weighted` 5
+    <> [ focus "input[type=text]" `weighted` 5 
+       , keyPress ' ' `weighted` 5
+       , keyPress 'a' `weighted` 5
        ]
 
 proposition :: Boolean

--- a/integration-tests/passing/MultiPage.spec.purs
+++ b/integration-tests/passing/MultiPage.spec.purs
@@ -2,7 +2,6 @@ module Spec where
 
 import Quickstrom
 import Data.Maybe (Maybe(..), isJust, isNothing)
-import Data.Tuple (Tuple(..))
 import Data.String (trim)
 
 readyWhen :: String
@@ -11,8 +10,10 @@ readyWhen = "body"
 actions :: Actions
 actions =
   clicks
-    <> [ Tuple 5 (Single $ Focus "input[type=text]") ]
-    <> [ Tuple 5 (Single $ KeyPress ' '), Tuple 5 (Single $ KeyPress 'a') ]
+    <> [ Focus "input[type=text]" `weighted` 5 
+       , KeyPress ' ' `weighted` 5
+       , KeyPress 'a' `weighted` 5
+       ]
 
 proposition :: Boolean
 proposition =

--- a/runner/src/Quickstrom/Action.hs
+++ b/runner/src/Quickstrom/Action.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
 
 module Quickstrom.Action where
 

--- a/runner/src/Quickstrom/Pretty.hs
+++ b/runner/src/Quickstrom/Pretty.hs
@@ -14,7 +14,7 @@ import Data.Function ((&))
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List as List
 import Data.Ord (comparing)
-import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc hiding (width)
 import Data.Text.Prettyprint.Doc.Render.Terminal
 import Data.Text.Prettyprint.Doc.Symbols.Unicode (bullet)
 import qualified Data.Vector as Vector
@@ -87,13 +87,17 @@ prettyObservedState (ObservedState _ (ObservedElementStates states))
             )
       )
   where
-    prettyMatchedElement (ObservedElementState element' _position stateValues) =
-      "-" <+> pretty element'
-        <> align
-          ( line
-              <> indent 2 (vsep (map prettyStateValue (HashMap.toList stateValues)))
-          )
+    prettyMatchedElement (ObservedElementState element' pos stateValues) =
+      "-"
+        <+> ( pretty element' <+> prettyPosition pos
+                <> line
+                <> indent 2 (vsep (map prettyStateValue (HashMap.toList stateValues)))
+            )
     prettyStateValue (state'', value) = "-" <+> prettyState state'' <+> "=" <+> prettyValue value
+
+prettyPosition :: Maybe Position -> Doc AnsiStyle
+prettyPosition Nothing = "(no position)"
+prettyPosition (Just pos) = parens (pretty (width pos) <> "x" <> pretty (height pos) <+> "at" <+> parens (pretty (x pos) <> ","  <+> pretty (y pos)))
 
 prettyValue :: JSON.Value -> Doc AnsiStyle
 prettyValue = \case

--- a/runner/src/Quickstrom/PureScript/Eval/Error.hs
+++ b/runner/src/Quickstrom/PureScript/Eval/Error.hs
@@ -85,6 +85,6 @@ require ss (ctor :: Proxy ctor) v = case v ^? _Ctor @ctor of
 accessField :: MonadError EvalError m => SourceSpan -> Text -> HashMap Text (Value ann) -> m (Value ann)
 accessField ss key obj =
   maybe
-    (throwError (UnexpectedError (Just ss) ("Key not present in object: " <> key)))
+    (throwError (UnexpectedError (Just ss) ("Key '" <> key <> "' not present in object: " <> show (void obj))))
     pure
     (HashMap.lookup key obj)

--- a/runner/src/Quickstrom/PureScript/ForeignFunction.hs
+++ b/runner/src/Quickstrom/PureScript/ForeignFunction.hs
@@ -88,7 +88,7 @@ instance
   ) =>
   ToForeignFunction m 1 (a -> Ret m b)
   where
-  toForeignFunction f = Ind $ \a -> 
+  toForeignFunction f = Ind $ \a ->
     toForeignFunction (f a)
 
 instance
@@ -99,7 +99,7 @@ instance
   ) =>
   ToForeignFunction m 2 (a -> b -> Ret m c)
   where
-  toForeignFunction f = Ind $ \a -> Ind $ \b -> 
+  toForeignFunction f = Ind $ \a -> Ind $ \b ->
     toForeignFunction (f a b)
 
 instance
@@ -111,7 +111,7 @@ instance
   ) =>
   ToForeignFunction m 3 (a -> b -> c -> Ret m d)
   where
-  toForeignFunction f = Ind $ \a -> Ind $ \b -> Ind $ \c -> 
+  toForeignFunction f = Ind $ \a -> Ind $ \b -> Ind $ \c ->
     toForeignFunction (f a b c)
 
 instance
@@ -124,7 +124,7 @@ instance
   ) =>
   ToForeignFunction m 4 (a -> b -> c -> d -> Ret m e)
   where
-  toForeignFunction f = Ind $ \a -> Ind $ \b -> Ind $ \c -> Ind $ \d -> 
+  toForeignFunction f = Ind $ \a -> Ind $ \b -> Ind $ \c -> Ind $ \d ->
     toForeignFunction (f a b c d)
 
 instance
@@ -138,7 +138,7 @@ instance
   ) =>
   ToForeignFunction m 5 (a -> b -> c -> d -> e -> Ret m f)
   where
-  toForeignFunction f = Ind $ \a -> Ind $ \b -> Ind $ \c -> Ind $ \d -> Ind $ \e -> 
+  toForeignFunction f = Ind $ \a -> Ind $ \b -> Ind $ \c -> Ind $ \d -> Ind $ \e ->
     toForeignFunction (f a b c d e)
 
 instance
@@ -153,7 +153,7 @@ instance
   ) =>
   ToForeignFunction m 6 (a -> b -> c -> d -> e -> f -> Ret m g)
   where
-  toForeignFunction f' = Ind $ \a -> Ind $ \b -> Ind $ \c -> Ind $ \d -> Ind $ \e -> Ind $ \f -> 
+  toForeignFunction f' = Ind $ \a -> Ind $ \b -> Ind $ \c -> Ind $ \d -> Ind $ \e -> Ind $ \f ->
     toForeignFunction (f' a b c d e f)
 
 class MonadError EvalError m => ToHaskellValue m r where
@@ -209,10 +209,12 @@ instance MonadError EvalError m => ToHaskellValue m (ActionSequence Selector) wh
   toHaskellValue ss v = do
     obj <- require ss (Proxy @"VObject") v
     ctor <- require ss (Proxy @"VString") =<< accessField ss "constructor" obj
-    value <- Vector.head <$> (require ss (Proxy @"VArray") =<< accessField ss "fields" obj)
-    case ctor of
-      "Single" -> ActionSequence . pure <$> toHaskellValue ss value
-      "Sequence" -> ActionSequence <$> toHaskellValue ss value
+    values <- require ss (Proxy @"VArray") =<< accessField ss "fields" obj
+    case (ctor, Vector.toList values) of
+      ("NonEmpty", [h, t]) -> do
+        h' <- toHaskellValue ss h
+        t' <- toHaskellValue ss t
+        pure (ActionSequence (h' :| t'))
       _ -> throwError (ForeignFunctionError (Just ss) ("Unknown ActionSequence constructor: " <> ctor))
 
 instance MonadError EvalError m => ToHaskellValue m (Action Selector) where
@@ -250,12 +252,12 @@ instance (Eval r m, FromHaskellValue a, ToHaskellValue m b) => ToHaskellValue m 
 instance (Eval r m, FromHaskellValue a, FromHaskellValue b, ToHaskellValue m c) => ToHaskellValue m (a -> b -> Ret m c) where
   toHaskellValue ss fn =
     pure
-    ( \a b -> Ret $ do
-        fn' <- require ss (Proxy @"VFunction") fn
-        fn'' <- require ss (Proxy @"VFunction") =<< evalFunc fn' (fromHaskellValue a)
-        c <- evalFunc fn'' (fromHaskellValue b)
-        toHaskellValue ss c
-    )
+      ( \a b -> Ret $ do
+          fn' <- require ss (Proxy @"VFunction") fn
+          fn'' <- require ss (Proxy @"VFunction") =<< evalFunc fn' (fromHaskellValue a)
+          c <- evalFunc fn'' (fromHaskellValue b)
+          toHaskellValue ss c
+      )
 
 class FromHaskellValue a where
   fromHaskellValue :: a -> Value EvalAnn

--- a/runner/src/Quickstrom/PureScript/Program.hs
+++ b/runner/src/Quickstrom/PureScript/Program.hs
@@ -347,7 +347,8 @@ foreignFunctions =
       (ffName "Math" "floor", foreignFunction (op1 (fromIntegral @Int @Double . floor @Double @Int))),
       (ffName "Math" "remainder", foreignFunction (op2 (mod' @Double))),
       (ffName "Partial.Unsafe" "unsafePartial", foreignFunction unsafePartial),
-      (ffName "Record.Unsafe" "unsafeGet", foreignFunction unsafeGet)
+      (ffName "Record.Unsafe" "unsafeGet", foreignFunction unsafeGet),
+      (ffName "Unsafe.Coerce" "unsafeCoerce", foreignFunction unsafeCoerce)
     ]
   where
     ffName mn n = QualifiedName (ModuleName <$> NonEmpty.fromList (Text.splitOn "." mn)) (Name n)
@@ -472,6 +473,8 @@ foreignFunctions =
       local (field @"env" .~ fenv {envForeignFunctions = envForeignFunctions env'}) (eval body)
     unsafeGet :: MonadError EvalError m => Text -> HashMap Text (Value EvalAnn) -> Ret m (Value EvalAnn)
     unsafeGet k xs = Ret (accessField P.nullSourceSpan k xs)
+    unsafeCoerce :: MonadError EvalError m => Value EvalAnn -> Ret m (Value EvalAnn)
+    unsafeCoerce = Ret . pure
     singletonCodePoint :: Monad m => Value EvalAnn -> Int -> Ret m Text
     singletonCodePoint _ i = singletonCodeUnits i
     singletonCodeUnits :: Monad m => Int -> Ret m Text

--- a/runner/src/Quickstrom/PureScript/Program.hs
+++ b/runner/src/Quickstrom/PureScript/Program.hs
@@ -195,7 +195,7 @@ loadProgram ms input = runExceptT $ do
 
 data SpecificationProgram = SpecificationProgram
   { specificationReadyWhen :: Quickstrom.Selector,
-    specificationActions :: Vector (Int, Quickstrom.ActionSequence Quickstrom.Selector),
+    specificationActions :: Vector (Quickstrom.Weighted (Quickstrom.ActionSequence Quickstrom.Selector)),
     specificationQueries :: Quickstrom.Queries,
     specificationProgram :: Program WithObservedStates
   }
@@ -203,7 +203,7 @@ data SpecificationProgram = SpecificationProgram
 instance Quickstrom.Specification SpecificationProgram where
   readyWhen = specificationReadyWhen
 
-  actions = map (uncurry Quickstrom.Weighted) . specificationActions
+  actions = specificationActions
 
   verify sp states = (_Left %~ (prettyText . prettyEvalError)) $ do
     valid <- toHaskellValue (moduleSourceSpan (programMain p)) =<< evalWithObservedStates p "proposition" states

--- a/runner/src/Quickstrom/Run.hs
+++ b/runner/src/Quickstrom/Run.hs
@@ -53,7 +53,7 @@ import Quickstrom.Action
 import Quickstrom.Element (Element)
 import Quickstrom.Prelude hiding (catch, check, trace)
 import Quickstrom.Result
-import Quickstrom.Run.Actions (awaitElement, defaultTimeout, generateValidActions, reselect, runActionSequence, shrinkAction, isCurrentlyValid)
+import Quickstrom.Run.Actions (awaitElement, defaultTimeout, generateValidActions, isCurrentlyValid, reselect, runActionSequence, shrinkAction)
 import Quickstrom.Run.Runner (CheckEnv (..), CheckOptions (..), Runner, Size (..), run)
 import Quickstrom.Run.Scripts (CheckScripts (..), readScripts, runCheckScript)
 import Quickstrom.Specification
@@ -186,7 +186,7 @@ runSingle spec size = do
         >-> Pipes.mapM (traverse reselect)
         >-> Pipes.mapMaybe (traverse identity)
         >-> Pipes.filterM isCurrentlyValid
-        & runAndVerifyIsolated n 
+        & runAndVerifyIsolated n
 
 runAll :: (MonadIO m, WebDriver m, Specification spec) => CheckOptions -> spec -> Producer CheckEvent (Runner m) CheckResult
 runAll opts spec' = go mempty (sizes opts `zip` [1 ..])

--- a/runner/src/Quickstrom/Run/Actions.hs
+++ b/runner/src/Quickstrom/Run/Actions.hs
@@ -24,6 +24,7 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Loops (andM)
 import Control.Monad.Trans.Class (MonadTrans (lift))
 import Data.List hiding (map)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Prettyprint.Doc
@@ -40,7 +41,6 @@ import Quickstrom.Timeout (Timeout (..))
 import Quickstrom.Trace (ActionResult (..))
 import Quickstrom.WebDriver.Class
 import qualified Test.QuickCheck as QuickCheck
-import qualified Data.List.NonEmpty as NonEmpty
 
 shrinkAction :: ActionSequence Selected -> [ActionSequence Selected]
 shrinkAction _ = [] -- TODO?

--- a/runner/src/Quickstrom/Run/Runner.hs
+++ b/runner/src/Quickstrom/Run/Runner.hs
@@ -7,9 +7,9 @@ module Quickstrom.Run.Runner where
 import Control.Monad.Catch (MonadCatch, MonadThrow)
 import qualified Data.Aeson as JSON
 import Quickstrom.Prelude hiding (catch, check, trace)
+import Quickstrom.Run.Scripts (CheckScripts)
 import Quickstrom.Timeout (Timeout)
 import Quickstrom.WebDriver.Class (WebDriver, WebDriverOptions)
-import Quickstrom.Run.Scripts (CheckScripts)
 import Text.URI (URI)
 
 data CheckEnv = CheckEnv {checkOptions :: CheckOptions, checkScripts :: CheckScripts}

--- a/runner/src/Quickstrom/Run/Scripts.hs
+++ b/runner/src/Quickstrom/Run/Scripts.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
+
 module Quickstrom.Run.Scripts where
 
 import Control.Monad (Monad (fail))

--- a/runner/src/Quickstrom/Specification.hs
+++ b/runner/src/Quickstrom/Specification.hs
@@ -1,11 +1,6 @@
 {-# LANGUAGE DataKinds #-}
-
 {-# LANGUAGE ExistentialQuantification #-}
-
-
-
 {-# LANGUAGE RankNTypes #-}
-
 
 module Quickstrom.Specification where
 

--- a/runner/src/Quickstrom/Timeout.hs
+++ b/runner/src/Quickstrom/Timeout.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 -- | A timeout in milliseconds.
 module Quickstrom.Timeout where
 
-import Quickstrom.Prelude
 import qualified Data.Aeson as JSON
+import Quickstrom.Prelude
 
 newtype Timeout = Timeout Word64
   deriving (Eq, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 
 mapTimeout :: (Word64 -> Word64) -> Timeout -> Timeout
 mapTimeout f (Timeout ms) = Timeout (f ms)
-

--- a/runner/src/Quickstrom/WebDriver/HsWebDriver.hs
+++ b/runner/src/Quickstrom/WebDriver/HsWebDriver.hs
@@ -31,8 +31,8 @@ instance WebDriver WebDriverClient where
   findAll (Selector s) = map fromRef <$> WebDriverClient (WebDriver.findElems (WebDriver.ByCSS s))
   navigateTo = WebDriverClient . WebDriver.openPage . toS
   goBack = WebDriverClient WebDriver.back
-  goForward = WebDriverClient WebDriver.forward 
-  pageRefresh = WebDriverClient WebDriver.refresh 
+  goForward = WebDriverClient WebDriver.forward
+  pageRefresh = WebDriverClient WebDriver.refresh
   runScript script args = do
     r <- WebDriverClient (WebDriver.asyncJS (map WebDriver.JSArg args) script)
     case r of

--- a/runner/test/Quickstrom/PureScriptTest/TodoMVC.spec.purs
+++ b/runner/test/Quickstrom/PureScriptTest/TodoMVC.spec.purs
@@ -1,7 +1,6 @@
 module TodoMVC where
 
 import Quickstrom
-import Quickstrom.Spec (Action(..), ActionSequence(..))
 import Data.Array (filter, foldMap, head, last, zip)
 import Data.Foldable (length)
 import Data.Int as Int
@@ -19,17 +18,17 @@ actions :: Actions
 actions = appFoci <> appClicks <> appKeyPresses
   where
   appClicks =
-    [ Tuple 5 $ Single $ Click queries.filters.notSelected
-    , Tuple 1 $ Single $ Click queries.filters.selected
-    , Tuple 1 $ Single $ Click queries.toggleAll
-    , Tuple 1 $ Single $ Click queries.destroy
+    [ Click queries.filters.notSelected `weighted` 5
+    , Click queries.filters.selected `weighted` 1
+    , Click queries.toggleAll `weighted` 1
+    , Click queries.destroy `weighted` 1
     ]
 
-  appFoci = [ Tuple 5 $ Single (Focus queries.newTodo) ]
+  appFoci = [ Focus queries.newTodo `weighted` 1 ]
 
   appKeyPresses =
-    [ Tuple 5 $ Single (keyPress 'a')
-    , Tuple 5 $ Single (specialKeyPress KeyReturn)
+    [ keyPress 'a' `weighted` 5
+    , specialKeyPress KeyReturn `weighted` 5
     ]
 
 proposition :: Boolean

--- a/runner/test/Quickstrom/PureScriptTest/TodoMVC.spec.purs
+++ b/runner/test/Quickstrom/PureScriptTest/TodoMVC.spec.purs
@@ -18,13 +18,13 @@ actions :: Actions
 actions = appFoci <> appClicks <> appKeyPresses
   where
   appClicks =
-    [ Click queries.filters.notSelected `weighted` 5
-    , Click queries.filters.selected `weighted` 1
-    , Click queries.toggleAll `weighted` 1
-    , Click queries.destroy `weighted` 1
+    [ click queries.filters.notSelected `weighted` 5
+    , click queries.filters.selected `weighted` 1
+    , click queries.toggleAll `weighted` 1
+    , click queries.destroy `weighted` 1
     ]
 
-  appFoci = [ Focus queries.newTodo `weighted` 1 ]
+  appFoci = [ focus queries.newTodo `weighted` 1 ]
 
   appKeyPresses =
     [ keyPress 'a' `weighted` 5

--- a/runner/test/Quickstrom/TraceTest.hs
+++ b/runner/test/Quickstrom/TraceTest.hs
@@ -9,9 +9,19 @@ import Data.Generics.Labels ()
 import qualified Quickstrom.Gen as Gen
 import Quickstrom.Prelude
 import Quickstrom.Trace
-import Test.QuickCheck (Property, forAll, (===))
+import Test.QuickCheck (Property, forAll, (===), (==>))
+import Test.QuickCheck.Arbitrary (arbitrary)
+import Test.QuickCheck.Modifiers (Positive (Positive))
+import Test.Tasty.QuickCheck (NonNegative (NonNegative))
 
 prop_all_empty_are_stuttering :: Property
 prop_all_empty_are_stuttering = forAll Gen.trace $ \t -> do
   let t' = t & observedStates .~ mempty
   (t' ^. observedStates . #elementStates) === (withoutStutterStates (annotateStutteringSteps t') ^. observedStates . #elementStates)
+
+prop_all_duplicates_are_stuttering :: Property
+prop_all_duplicates_are_stuttering = forAll (Gen.observedState >>= Gen.traceWithState . pure) $ \t -> do
+  lengthOf
+    (observedStates . #elementStates)
+    (withoutStutterStates (annotateStutteringSteps t))
+    === 1


### PR DESCRIPTION
This provides a new syntax for actions in specs. See https://quickstrom--89.org.readthedocs.build/en/89/topics/specification-language.html#actions for the new docs.

@johanatan This is likely affecting your specs, right? I've released a version 0.2.0 before this PR if you want to stick with that for now. But the changes required for the new syntax shouldn't be too big.