### PR TITLE
fix https://github.com/quickstrom/quickstrom/issues/120

### DIFF
--- a/quickstrom/executor.py
+++ b/quickstrom/executor.py
@@ -217,7 +217,7 @@ class Check():
 
                 return result.map_states(r, on_state)
 
-            def await_events(driver, deps, state_version, timeout: int):
+            def await_events(driver, deps, state_version, timeout: int, msg_id):
                 def on_no_events():
                     state = scripts.query_state(driver, deps)
                     screenshot(driver, dict_hash(state))
@@ -229,13 +229,16 @@ class Check():
                     events = scripts.await_events(driver, deps, timeout)
                     self.log.debug(f"Change: {events}")
 
-                    if events is None:
+                    if events is None or msg_id == 'noop':
                         self.log.info(f"Timed out!")
                         on_no_events()
                     else:
                         screenshot(driver, dict_hash(events.state))
                         state_version.increment()
                         send(Events(events.events, events.state))
+                        #if msg_id == 'noop':
+                            #state = scripts.query_state(driver, deps)
+                            #send(Timeout(state=state))
                 except StaleElementReferenceException as e:
                     self.log.error(f"Stale element reference: {e}")
                     on_no_events()
@@ -267,7 +270,7 @@ class Check():
                             scripts.install_event_listener(
                                 driver, msg.dependencies)
                             await_events(driver, msg.dependencies,
-                                         state_version, 10000)
+                                         state_version, 10000, 'start')
 
                             await_session_commands(driver, msg.dependencies,
                                                    state_version)
@@ -320,7 +323,7 @@ class Check():
 
                                 if msg.action.timeout is not None:
                                     await_events(driver, deps, state_version,
-                                                 msg.action.timeout)
+                                                 msg.action.timeout, msg.action.id)
                             else:
                                 self.log.warn(
                                     f"Got stale message ({msg}) in state {state_version.value}"
@@ -333,7 +336,7 @@ class Check():
                                 )
                                 scripts.install_event_listener(driver, deps)
                                 await_events(driver, deps, state_version,
-                                             msg.await_timeout)
+                                             msg.await_timeout, msg.action.id)
                             else:
                                 self.log.warn(
                                     f"Got stale message ({msg}) in state {state_version.value}"


### PR DESCRIPTION
Producing at least an immediate timeout when another ui event is sent during a noop, so that further transitions can happen.  